### PR TITLE
Small fix for unittests with nogc/nothrow

### DIFF
--- a/src/clib/iterator.d
+++ b/src/clib/iterator.d
@@ -46,35 +46,36 @@ private bool IS_VALID_ITERABLE(T)() @nogc nothrow {
     }
 }
 
-unittest {
-    int[12] arr = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
-    auto f = forward_iterator!(typeof(arr), int)(arr, arr.length);
-    int i = 0;
-    foreach (int el; f) {
-        assert(el == i + 1);
-        ++i;
+@nogc nothrow {
+    unittest {
+        int[12] arr = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
+        auto f = forward_iterator!(typeof(arr), int)(arr, arr.length);
+        int i = 0;
+        foreach (int el; f) {
+            assert(el == i + 1);
+            ++i;
+        }
+    }
+
+    unittest {
+        import clib.string;
+        cstring s = "testing my patience";
+        string t = "testing my patience";
+        int i = 0;
+        foreach (char c; forward_iterator!(cstring, char)(s, s.size)) {
+            assert(c == t[i]);
+            ++i;
+        }
+    }
+
+    unittest {
+        import clib.string;
+        cstring s = "testing my patience";
+        string t = "testing my patience";
+        int i = cast(int) s.size - 1;
+        foreach_reverse (char c; backward_iterator!(cstring, char)(s, s.size)) {
+            assert(c == t[i]);
+            --i;
+        }
     }
 }
-
-unittest {
-    import clib.string;
-    cstring s = "testing my patience";
-    string t = "testing my patience";
-    int i = 0;
-    foreach (char c; forward_iterator!(cstring, char)(s, s.size)) {
-        assert(c == t[i]);
-        ++i;
-    }
-}
-
-unittest {
-    import clib.string;
-    cstring s = "testing my patience";
-    string t = "testing my patience";
-    int i = cast(int) s.size - 1;
-    foreach_reverse (char c; backward_iterator!(cstring, char)(s, s.size)) {
-        assert(c == t[i]);
-        --i;
-    }
-}
-

--- a/src/clib/optional.d
+++ b/src/clib/optional.d
@@ -113,74 +113,73 @@ struct optional(T) {
     }
 }
 
-@nogc nothrow:
-// Unittests
+@nogc nothrow {
+    // Unittests
+    unittest {
+        optional!int opt;
+        assert(opt.has_value == false);
+        assert(opt.valueOr(5) == 5);
+        opt = 1;
+        assert(opt.has_value == true);
+        assert(opt.value == 1);
+    }
 
-unittest {
-    optional!int opt;
-    assert(opt.has_value == false);
-    assert(opt.valueOr(5) == 5);
-    opt = 1;
-    assert(opt.has_value == true);
-    assert(opt.value == 1);
+    unittest {
+        optional!int opt;
+        opt = 2;
+        opt = null;
+        assert(opt.has_value == false);
+        assert(opt.valueOr(5) == 5);
+        opt = optional!int(3);
+        assert(opt == 3);
+        assert(opt != null);
+        optional!int b = optional!int(3);
+        assert(opt == b);
+    }
+
+    unittest {
+        optional!int a = 4;
+        optional!int b;
+        a.swap(b);
+        assert(a == null);
+        assert(b == 4);
+        b.reset();
+        assert(b == null);
+    }
+
+    unittest {
+        import clib.vector;
+        optional!(vector!int) a;
+        vector!int v = vector!int(1, 2, 3, 4);
+        a = v;
+        assert(a.has_value);
+        assert(a.value == [1, 2, 3, 4]);
+        optional!(vector!int) b;
+        b = a;
+        assert(a.has_value);
+        assert(a.value == [1, 2, 3, 4]);
+        assert(b.has_value);
+        assert(b.value == [1, 2, 3, 4]);
+        assert(a == b);
+        import clib.stdlib;
+        void test1(optional!(vector!int) o) { free(o.value.release()); }
+        void test2(vector!int v) { free(v.release()); }
+
+        test1(a);
+        test2(a.value);
+
+        assert(a.has_value);
+        assert(a.value == [1, 2, 3, 4]);
+        assert(b.has_value);
+        assert(b.value == [1, 2, 3, 4]);
+        assert(a == b);
+    }
+
+    unittest {
+        import clib.vector;
+        optional!int o1 = 15;
+        optional!(vector!int) o2 = vector!int(1, 2, 3);
+        cast(void) o1.toHash;
+        cast(void) o2.toHash;
+    }
 }
-
-unittest {
-    optional!int opt;
-    opt = 2;
-    opt = null;
-    assert(opt.has_value == false);
-    assert(opt.valueOr(5) == 5);
-    opt = optional!int(3);
-    assert(opt == 3);
-    assert(opt != null);
-    optional!int b = optional!int(3);
-    assert(opt == b);
-}
-
-unittest {
-    optional!int a = 4;
-    optional!int b;
-    a.swap(b);
-    assert(a == null);
-    assert(b == 4);
-    b.reset();
-    assert(b == null);
-}
-
-unittest {
-    import clib.vector;
-    optional!(vector!int) a;
-    vector!int v = vector!int(1, 2, 3, 4);
-    a = v;
-    assert(a.has_value);
-    assert(a.value == [1, 2, 3, 4]);
-    optional!(vector!int) b;
-    b = a;
-    assert(a.has_value);
-    assert(a.value == [1, 2, 3, 4]);
-    assert(b.has_value);
-    assert(b.value == [1, 2, 3, 4]);
-    assert(a == b);
-    import clib.stdlib;
-    void test1(optional!(vector!int) o) { free(o.value.release()); }
-    void test2(vector!int v) { free(v.release()); }
-
-    test1(a);
-    test2(a.value);
-
-    assert(a.has_value);
-    assert(a.value == [1, 2, 3, 4]);
-    assert(b.has_value);
-    assert(b.value == [1, 2, 3, 4]);
-    assert(a == b);
-}
-
-unittest {
-    import clib.vector;
-    optional!int o1 = 15;
-    optional!(vector!int) o2 = vector!int(1, 2, 3);
-    cast(void) o1.toHash;
-    cast(void) o2.toHash;
-}
-

--- a/src/clib/queue.d
+++ b/src/clib/queue.d
@@ -173,53 +173,53 @@ struct queue(T, A: IAllocator!T = allocator!T) {
     }
 }
 
-@nogc nothrow:
-// Unittests
+@nogc nothrow {
+    // Unittests
+    unittest {
+        queue!int q = queue!int(1, 2, 3, 4);
+        assert(q.size == 4);
+        assert(q.pop == 1);
+        assert(q.pop == 2);
+        assert(q.pop == 3);
+        assert(q.front == 4);
+        assert(q.pop == 4);
+        assert(q.size == 0);
+        assert(q.pop == int.init);
+    }
 
-unittest {
-    queue!int q = queue!int(1, 2, 3, 4);
-    assert(q.size == 4);
-    assert(q.pop == 1);
-    assert(q.pop == 2);
-    assert(q.pop == 3);
-    assert(q.front == 4);
-    assert(q.pop == 4);
-    assert(q.size == 0);
-    assert(q.pop == int.init);
+    unittest {
+        queue!int q;
+        assert(q.empty);
+        assert(q.front == int.init);
+        q.push(3, 2, 1);
+        assert(q.front == 3);
+        q ~= 3;
+        q.push(2);
+        assert(q.front == 3);
+        assert(q.array == [3, 2, 1, 3, 2]);
+    }
+
+    unittest {
+        queue!int q = queue!int(1, 2, 3, 4);
+        q.clear();
+        assert(q.size == 0);
+        assert(q.pop == int.init);
+    }
+
+    unittest {
+        queue!int q = queue!int(1, 2, 3, 4);
+        q.push(5, 6, 7, 8, 9, 10);
+        q.limit_length(7);
+        assert(q.size == 7);
+        assert(q.array == [1, 2, 3, 4, 5, 6, 7]);
+    }
+
+    unittest {
+        queue!int q = queue!int(1, 2, 3, 4);
+        queue!int w = q.clone();
+        assert(q.array.array == w.array.array);
+        w.pop();
+        assert(q.array.array != w.array.array);
+    }
+
 }
-
-unittest {
-    queue!int q;
-    assert(q.empty);
-    assert(q.front == int.init);
-    q.push(3, 2, 1);
-    assert(q.front == 3);
-    q ~= 3;
-    q.push(2);
-    assert(q.front == 3);
-    assert(q.array == [3, 2, 1, 3, 2]);
-}
-
-unittest {
-    queue!int q = queue!int(1, 2, 3, 4);
-    q.clear();
-    assert(q.size == 0);
-    assert(q.pop == int.init);
-}
-
-unittest {
-    queue!int q = queue!int(1, 2, 3, 4);
-    q.push(5, 6, 7, 8, 9, 10);
-    q.limit_length(7);
-    assert(q.size == 7);
-    assert(q.array == [1, 2, 3, 4, 5, 6, 7]);
-}
-
-unittest {
-    queue!int q = queue!int(1, 2, 3, 4);
-    queue!int w = q.clone();
-    assert(q.array.array == w.array.array);
-    w.pop();
-    assert(q.array.array != w.array.array);
-}
-

--- a/src/clib/set.d
+++ b/src/clib/set.d
@@ -217,73 +217,72 @@ private bool sort_function(T)(T a, T b) @nogc nothrow {
     }
 }
 
-@nogc nothrow:
-// Unittests
+@nogc nothrow {
+    // Unittests
+    unittest {
+        set!int s = set!int(3, 2, 1, 4, 12, 0);
+        assert(s == [0, 1, 2, 3, 4, 12]);
+        assert(s.size == 6);
+        assert(s.front == 0);
+        assert(s.back == 12);
+        s.clear();
+        assert(s.empty);
+        assert(s.size == 0);
+    }
 
-unittest {
-    set!int s = set!int(3, 2, 1, 4, 12, 0);
-    assert(s == [0, 1, 2, 3, 4, 12]);
-    assert(s.size == 6);
-    assert(s.front == 0);
-    assert(s.back == 12);
-    s.clear();
-    assert(s.empty);
-    assert(s.size == 0);
+    unittest {
+        set!int s = set!int(1, 2, 3);
+        s ~= 4;
+        int[2] arr = [0, -1];
+        s ~= arr;
+        assert(s == [-1, 0, 1, 2, 3, 4]);
+    }
+
+    unittest {
+        set!int s = set!int(1, 2, 3);
+        s.insert(-1, 2, 5, 6, 12);
+        assert(s == [-1, 1, 2, 3, 5, 6, 12]);
+        assert(s.has(1));
+        assert(!s.has(15));
+    }
+
+    unittest {
+        set!int s;
+        s.reserve(12);
+        assert(s.capacity == 12);
+        assert(s.size == 0);
+        s.insert(2);
+        s.shrink();
+        assert(s.size == 1);
+        assert(s == [2]);
+        assert(s.capacity == 1);
+    }
+
+    unittest {
+        set!(char*) s;
+        char*[5] a = [
+            cast(char*)"abcd".ptr,
+            cast(char*)"cbda".ptr,
+            cast(char*)"dcba".ptr,
+            cast(char*)"add".ptr,
+            cast(char*)"remove".ptr
+        ];
+        s.insert(a);
+        char*[5] b = [
+            cast(char*)"add".ptr,
+            cast(char*)"abcd".ptr,
+            cast(char*)"cbda".ptr,
+            cast(char*)"dcba".ptr,
+            cast(char*)"remove".ptr
+        ];
+        import clib.string: strcmp;
+        assert(strcmp(s[0], cast(char*) "abcd".ptr) == 0);
+        assert(strcmp(s[1], cast(char*) "add".ptr) == 0);
+    }
+
+    unittest {
+        bool revFunc(int a, int b) @nogc nothrow {return a < b;}
+        set!(int, revFunc) s = set!(int, revFunc)(1, 2, 3, 5, 12, 0);
+        assert(s == [12, 5, 3, 2, 1, 0]);
+    }
 }
-
-unittest {
-    set!int s = set!int(1, 2, 3);
-    s ~= 4;
-    int[2] arr = [0, -1];
-    s ~= arr;
-    assert(s == [-1, 0, 1, 2, 3, 4]);
-}
-
-unittest {
-    set!int s = set!int(1, 2, 3);
-    s.insert(-1, 2, 5, 6, 12);
-    assert(s == [-1, 1, 2, 3, 5, 6, 12]);
-    assert(s.has(1));
-    assert(!s.has(15));
-}
-
-unittest {
-    set!int s;
-    s.reserve(12);
-    assert(s.capacity == 12);
-    assert(s.size == 0);
-    s.insert(2);
-    s.shrink();
-    assert(s.size == 1);
-    assert(s == [2]);
-    assert(s.capacity == 1);
-}
-
-unittest {
-    set!(char*) s;
-    char*[5] a = [
-        cast(char*)"abcd".ptr,
-        cast(char*)"cbda".ptr,
-        cast(char*)"dcba".ptr,
-        cast(char*)"add".ptr,
-        cast(char*)"remove".ptr
-    ];
-    s.insert(a);
-    char*[5] b = [
-        cast(char*)"add".ptr,
-        cast(char*)"abcd".ptr,
-        cast(char*)"cbda".ptr,
-        cast(char*)"dcba".ptr,
-        cast(char*)"remove".ptr
-    ];
-    import clib.string: strcmp;
-    assert(strcmp(s[0], cast(char*) "abcd".ptr) == 0);
-    assert(strcmp(s[1], cast(char*) "add".ptr) == 0);
-}
-
-unittest {
-    bool revFunc(int a, int b) @nogc nothrow {return a < b;}
-    set!(int, revFunc) s = set!(int, revFunc)(1, 2, 3, 5, 12, 0);
-    assert(s == [12, 5, 3, 2, 1, 0]);
-}
-

--- a/src/clib/stack.d
+++ b/src/clib/stack.d
@@ -179,53 +179,52 @@ struct stack(T, A: IAllocator!T = allocator!T) {
     }
 }
 
-@nogc nothrow:
-// Unittests
+@nogc nothrow {
+    // Unittests
+    unittest {
+        stack!int q = stack!int(1, 2, 3, 4);
+        assert(q.size == 4);
+        assert(q.pop == 4);
+        assert(q.pop == 3);
+        assert(q.pop == 2);
+        assert(q.front == 1);
+        assert(q.pop == 1);
+        assert(q.size == 0);
+        assert(q.pop == int.init);
+    }
 
-unittest {
-    stack!int q = stack!int(1, 2, 3, 4);
-    assert(q.size == 4);
-    assert(q.pop == 4);
-    assert(q.pop == 3);
-    assert(q.pop == 2);
-    assert(q.front == 1);
-    assert(q.pop == 1);
-    assert(q.size == 0);
-    assert(q.pop == int.init);
+    unittest {
+        stack!int q;
+        assert(q.empty);
+        assert(q.front == int.init);
+        q.push(3, 2, 1);
+        assert(q.front == 1);
+        q ~= 3;
+        q.push(2);
+        assert(q.front == 2);
+        assert(q.array == [2, 3, 1, 2, 3]);
+    }
+
+    unittest {
+        stack!int q = stack!int(1, 2, 3, 4);
+        q.clear();
+        assert(q.size == 0);
+        assert(q.pop == int.init);
+    }
+
+    unittest {
+        stack!int q = stack!int(1, 2, 3, 4);
+        q.push(5, 6, 7, 8, 9, 10);
+        q.limit_length(7);
+        assert(q.size == 7);
+        assert(q.array == [10, 9, 8, 7, 6, 5, 4]);
+    }
+
+    unittest {
+        stack!int q = stack!int(1, 2, 3, 4);
+        stack!int w = q.clone();
+        assert(q.array.array == w.array.array);
+        w.pop();
+        assert(q.array.array != w.array.array);
+    }
 }
-
-unittest {
-    stack!int q;
-    assert(q.empty);
-    assert(q.front == int.init);
-    q.push(3, 2, 1);
-    assert(q.front == 1);
-    q ~= 3;
-    q.push(2);
-    assert(q.front == 2);
-    assert(q.array == [2, 3, 1, 2, 3]);
-}
-
-unittest {
-    stack!int q = stack!int(1, 2, 3, 4);
-    q.clear();
-    assert(q.size == 0);
-    assert(q.pop == int.init);
-}
-
-unittest {
-    stack!int q = stack!int(1, 2, 3, 4);
-    q.push(5, 6, 7, 8, 9, 10);
-    q.limit_length(7);
-    assert(q.size == 7);
-    assert(q.array == [10, 9, 8, 7, 6, 5, 4]);
-}
-
-unittest {
-    stack!int q = stack!int(1, 2, 3, 4);
-    stack!int w = q.clone();
-    assert(q.array.array == w.array.array);
-    w.pop();
-    assert(q.array.array != w.array.array);
-}
-

--- a/src/clib/vector.d
+++ b/src/clib/vector.d
@@ -519,208 +519,209 @@ struct vector(T, A: IAllocator!T = allocator!T) if (!is(T == bool)) {
 
 // Unittests
 // TODO: more edge cases
-@nogc nothrow:
+@nogc nothrow {
 
-unittest {
-    int[3] testArr = [2, 5, 6];
-    vector!int v = testArr;
-    assert(v[0..$] == [2, 5, 6]);
+    unittest {
+        int[3] testArr = [2, 5, 6];
+        vector!int v = testArr;
+        assert(v[0..$] == [2, 5, 6]);
 
-    v = vector!int(1, 4, 2);
-    assert(v.array == [1, 4, 2]);
+        v = vector!int(1, 4, 2);
+        assert(v.array == [1, 4, 2]);
+    }
+
+    unittest {
+        int[3] a = [1, 2, 3];
+        vector!int v = a;
+        v ~= 2;
+        assert(v[0..$] == [1, 2, 3, 2]);
+        v ~= a;
+        assert(v[0..$] == [1, 2, 3, 2, 1, 2, 3]);
+    }
+
+    unittest {
+        int[3] a = [1, 2, 3];
+        vector!int v = a;
+        assert(v[1] == 2);
+        v[1] = 4;
+        assert(v[0..$] == [1, 4, 3]);
+        v = 2;
+        assert(v[0..$] == [2, 2, 2]);
+    }
+
+    unittest {
+        vector!int a = vector!int(1, 2, 3, 4);
+        vector!int b = vector!int(1, 2, 3, 4);
+        assert(a == b);
+        b = vector!int(1, 2, 3, 5);
+        assert(a != b);
+    }
+
+    unittest {
+        int[3] a = [1, 2, 3];
+        vector!int v = vector!int(3, 2, 1);
+        assert(v != a);
+        assert(v != [1, 3, 2]);
+        assert(v == [3, 2, 1]);
+        vector!int vb = vector!int(3, 2, 1);
+        assert(v == vb);
+        vb = vector!int(1, 2, 3);
+        assert(v != vb);
+        vb = vector!int(3, 2, 1, 0);
+        assert(v != vb);
+    }
+
+    unittest {
+        int[3] a = [1, 2, 3];
+        vector!int v = vector!int(3, 2, 1);
+        vector!int b = v ~ a;
+        assert(b == [3, 2, 1, 1, 2, 3]);
+        b = a ~ v;
+        assert(b == [1, 2, 3, 3, 2, 1]);
+        b = a;
+        b = v ~ b;
+        assert(b == [3, 2, 1, 1, 2, 3]);
+    }
+
+    unittest {
+        int[4] data = [1, 2, 3, 4];
+        vector!int k;
+        k.assign_copy(data.ptr, 4);
+        assert(k[0..$] == [1, 2, 3, 4]);
+        k.free();
+
+        import clib.string;
+        import clib.stdlib;
+        int* d = cast(int*) malloc(4 * int.sizeof);
+        memcpy(d, data.ptr, 4 * int.sizeof);
+        vector!int v;
+        v.assign_pointer(d, 4);
+        assert(v[0..$] == [1, 2, 3, 4]);
+        v.free();
+    }
+
+    unittest {
+        int[3] a = [1, 2, 3];
+        vector!int v = a;
+        assert(v.size == 3);
+
+        assert(v.resize(6));
+        assert(v.size == 6);
+
+        assert(v.reserve(12));
+        assert(v.capacity == 12);
+        assert(v.size == 6);
+    }
+
+    unittest {
+        int[3] a = [1, 2, 3];
+        vector!int v = a;
+        assert(v.front == 1);
+        assert(v.back == 3);
+        v.push(4, 5);
+        assert(v.array == [1, 2, 3, 4, 5]);
+        v.push_front(0);
+        assert(v.array == [0, 1, 2, 3, 4, 5]);
+        v.push_front(-2, -1);
+        assert(v.array == [-2, -1, 0, 1, 2, 3, 4, 5]);
+    }
+
+    unittest {
+        vector!char c = "words are not enough";
+        c.erase(9, 12);
+        assert(c.array == "words are enough", c.array);
+        vector!int v = vector!int(0, 1, 2, 3, 4, 5, 6);
+        v.erase(3, 4);
+        assert(v.array == [0, 1, 2, 5, 6]);
+        assert(v.size == 5);
+        vector!int q = vector!int(0, 1, 2, 3, 4, 5, 6, 7, 8);
+        q.erase(2, 5);
+        assert(q.array == [0, 1, 6, 7, 8]);
+        assert(q.size == 5);
+        q.erase(0, 1);
+        assert(q.array == [6, 7, 8]);
+        assert(q.size == 3);
+        q.erase(1, 2);
+        assert(q.array == [6]);
+        assert(q.size == 1);
+
+    }
+
+    unittest {
+        vector!int v = vector!int(0, 1, 2, 3, 4, 5, 6);
+        assert(v.reserve(20));
+        assert(v.shrink());
+        assert(v.size == 7);
+    }
+
+    unittest {
+        vector!int v = vector!int(0, 1, 2, 3, 4, 5, 6);
+        v.pop();
+        v.pop_front();
+        assert(v.array == [1, 2, 3, 4, 5]);
+        v.clear();
+        assert(v.pop_front() == int.init);
+        assert(v.pop() == int.init);
+        assert(v.size == 0);
+    }
+
+    unittest {
+        vector!int v = vector!int(0, 1, 2, 3);
+        v.insert(2, 12);
+        assert(v.array == [0, 1, 12, 2, 3]);
+        v.insert(0, 13);
+        assert(v.array == [13, 0, 1, 12, 2, 3]);
+        v.insert(v.size - 1, 14);
+        assert(v.array == [13, 0, 1, 12, 2, 14, 3]);
+        v.insert(v.size, 15);
+        assert(v.array == [13, 0, 1, 12, 2, 14, 3]);
+    }
+
+    unittest {
+        vector!int va = vector!int(0, 1);
+        vector!int vb = vector!int(2, 3);
+        va.swap(&vb);
+        assert(va.array == [2, 3]);
+        assert(vb.array == [0, 1]);
+    }
+
+    unittest {
+        vector!int v = vector!int(0);
+        v.clear();
+        assert(v.size == 0);
+        assert(v.capacity == 1);
+    }
+
+    unittest {
+        vector!char v = "testing man";
+        assert(v == "testing man");
+    }
+
+    unittest {
+        vector!char v;
+        v ~= "test";
+        char[4] t = ['t', 'e', 's', 't'];
+        assert(v == t);
+        assert(v == "test");
+    }
+
+    unittest {
+        vector!char v = "no ";
+        vector!char n = v ~ "test";
+        assert(n == "no test");
+        n = "there is " ~ n ~ " at all";
+        assert(n == "there is no test at all");
+    }
+
+    unittest {
+        vector!char v = "test";
+        char[5] a = ['t', 'e', 's', 't', '\0'];
+        import clib.string: strcmp;
+        assert(strcmp(v.stringz.data, a.ptr) == 0);
+        char* sz = v.stringz.release();
+        assert(strcmp(sz, a.ptr) == 0);
+        import clib.stdlib;
+        free(sz);
+    }
+
 }
-
-unittest {
-    int[3] a = [1, 2, 3];
-    vector!int v = a;
-    v ~= 2;
-    assert(v[0..$] == [1, 2, 3, 2]);
-    v ~= a;
-    assert(v[0..$] == [1, 2, 3, 2, 1, 2, 3]);
-}
-
-unittest {
-    int[3] a = [1, 2, 3];
-    vector!int v = a;
-    assert(v[1] == 2);
-    v[1] = 4;
-    assert(v[0..$] == [1, 4, 3]);
-    v = 2;
-    assert(v[0..$] == [2, 2, 2]);
-}
-
-unittest {
-    vector!int a = vector!int(1, 2, 3, 4);
-    vector!int b = vector!int(1, 2, 3, 4);
-    assert(a == b);
-    b = vector!int(1, 2, 3, 5);
-    assert(a != b);
-}
-
-unittest {
-    int[3] a = [1, 2, 3];
-    vector!int v = vector!int(3, 2, 1);
-    assert(v != a);
-    assert(v != [1, 3, 2]);
-    assert(v == [3, 2, 1]);
-    vector!int vb = vector!int(3, 2, 1);
-    assert(v == vb);
-    vb = vector!int(1, 2, 3);
-    assert(v != vb);
-    vb = vector!int(3, 2, 1, 0);
-    assert(v != vb);
-}
-
-unittest {
-    int[3] a = [1, 2, 3];
-    vector!int v = vector!int(3, 2, 1);
-    vector!int b = v ~ a;
-    assert(b == [3, 2, 1, 1, 2, 3]);
-    b = a ~ v;
-    assert(b == [1, 2, 3, 3, 2, 1]);
-    b = a;
-    b = v ~ b;
-    assert(b == [3, 2, 1, 1, 2, 3]);
-}
-
-unittest {
-    int[4] data = [1, 2, 3, 4];
-    vector!int k;
-    k.assign_copy(data.ptr, 4);
-    assert(k[0..$] == [1, 2, 3, 4]);
-    k.free();
-
-    import clib.string;
-    import clib.stdlib;
-    int* d = cast(int*) malloc(4 * int.sizeof);
-    memcpy(d, data.ptr, 4 * int.sizeof);
-    vector!int v;
-    v.assign_pointer(d, 4);
-    assert(v[0..$] == [1, 2, 3, 4]);
-    v.free();
-}
-
-unittest {
-    int[3] a = [1, 2, 3];
-    vector!int v = a;
-    assert(v.size == 3);
-
-    assert(v.resize(6));
-    assert(v.size == 6);
-
-    assert(v.reserve(12));
-    assert(v.capacity == 12);
-    assert(v.size == 6);
-}
-
-unittest {
-    int[3] a = [1, 2, 3];
-    vector!int v = a;
-    assert(v.front == 1);
-    assert(v.back == 3);
-    v.push(4, 5);
-    assert(v.array == [1, 2, 3, 4, 5]);
-    v.push_front(0);
-    assert(v.array == [0, 1, 2, 3, 4, 5]);
-    v.push_front(-2, -1);
-    assert(v.array == [-2, -1, 0, 1, 2, 3, 4, 5]);
-}
-
-unittest {
-    vector!char c = "words are not enough";
-    c.erase(9, 12);
-    assert(c.array == "words are enough", c.array);
-    vector!int v = vector!int(0, 1, 2, 3, 4, 5, 6);
-    v.erase(3, 4);
-    assert(v.array == [0, 1, 2, 5, 6]);
-    assert(v.size == 5);
-    vector!int q = vector!int(0, 1, 2, 3, 4, 5, 6, 7, 8);
-    q.erase(2, 5);
-    assert(q.array == [0, 1, 6, 7, 8]);
-    assert(q.size == 5);
-    q.erase(0, 1);
-    assert(q.array == [6, 7, 8]);
-    assert(q.size == 3);
-    q.erase(1, 2);
-    assert(q.array == [6]);
-    assert(q.size == 1);
-
-}
-
-unittest {
-    vector!int v = vector!int(0, 1, 2, 3, 4, 5, 6);
-    assert(v.reserve(20));
-    assert(v.shrink());
-    assert(v.size == 7);
-}
-
-unittest {
-    vector!int v = vector!int(0, 1, 2, 3, 4, 5, 6);
-    v.pop();
-    v.pop_front();
-    assert(v.array == [1, 2, 3, 4, 5]);
-    v.clear();
-    assert(v.pop_front() == int.init);
-    assert(v.pop() == int.init);
-    assert(v.size == 0);
-}
-
-unittest {
-    vector!int v = vector!int(0, 1, 2, 3);
-    v.insert(2, 12);
-    assert(v.array == [0, 1, 12, 2, 3]);
-    v.insert(0, 13);
-    assert(v.array == [13, 0, 1, 12, 2, 3]);
-    v.insert(v.size - 1, 14);
-    assert(v.array == [13, 0, 1, 12, 2, 14, 3]);
-    v.insert(v.size, 15);
-    assert(v.array == [13, 0, 1, 12, 2, 14, 3]);
-}
-
-unittest {
-    vector!int va = vector!int(0, 1);
-    vector!int vb = vector!int(2, 3);
-    va.swap(&vb);
-    assert(va.array == [2, 3]);
-    assert(vb.array == [0, 1]);
-}
-
-unittest {
-    vector!int v = vector!int(0);
-    v.clear();
-    assert(v.size == 0);
-    assert(v.capacity == 1);
-}
-
-unittest {
-    vector!char v = "testing man";
-    assert(v == "testing man");
-}
-
-unittest {
-    vector!char v;
-    v ~= "test";
-    char[4] t = ['t', 'e', 's', 't'];
-    assert(v == t);
-    assert(v == "test");
-}
-
-unittest {
-    vector!char v = "no ";
-    vector!char n = v ~ "test";
-    assert(n == "no test");
-    n = "there is " ~ n ~ " at all";
-    assert(n == "there is no test at all");
-}
-
-unittest {
-    vector!char v = "test";
-    char[5] a = ['t', 'e', 's', 't', '\0'];
-    import clib.string: strcmp;
-    assert(strcmp(v.stringz.data, a.ptr) == 0);
-    char* sz = v.stringz.release();
-    assert(strcmp(sz, a.ptr) == 0);
-    import clib.stdlib;
-    free(sz);
-}
-


### PR DESCRIPTION
Hello Alisa,

This PR is to make all the unittests in these modules work properly. Apparently when '@nogc nothrow:' is used with a colon, only the next scope is affected, whereas when using '@nogc nothrow {}' with all the unittests in the new scope, it works properly and all tests are run. The docs state that @nogc, nothrow and pure are not propogated into aggregates, but I guess that also applies to unittests (which are considered functions, I think)?

I was trying to add some tests and it seemed they weren't being picked up, so I tested the second (or fifth or whatever) unittest in vector.d and changed a couple values to fail on purpose...but that didn't lead to an assert! So, then I tested with all unittests inside their own scope and things worked properly.

There will be another PR with the same change in list.d, but I have added other functionality there and will push separately.